### PR TITLE
Remove some non-printing characters from the code.

### DIFF
--- a/src/chatty/gui/components/settings/HighlighterTester.java
+++ b/src/chatty/gui/components/settings/HighlighterTester.java
@@ -170,8 +170,8 @@ public class HighlighterTester extends JDialog implements StringEditor {
         testInput.setPreferredSize(new Dimension(0, 50));
         testInput.setFont(Font.decode(Font.MONOSPACED));
         // Enable focus traversal keys
-        testInput.setFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERS‌​AL_KEYS, null);
-        testInput.setFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERS‌​AL_KEYS, null);
+        testInput.setFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS, null);
+        testInput.setFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS, null);
         GuiUtil.installLengthLimitDocumentFilter(testInput, 1000, false);
         add(new JScrollPane(testInput),
                 gbc);


### PR DESCRIPTION
This fixes errors in Eclipse and VS Code.